### PR TITLE
Default to extended mode for function 3

### DIFF
--- a/geosupport/geosupport.py
+++ b/geosupport/geosupport.py
@@ -105,6 +105,8 @@ class Geosupport(object):
     def call(self, kwargs_dict=None, mode=None, **kwargs):
         if kwargs_dict is None:
             kwargs_dict = {}
+        if kwargs.get("function") == "3" and mode is None:
+            mode = "extended"
         kwargs_dict.update(kwargs)
         kwargs_dict.update(set_mode(mode))
 


### PR DESCRIPTION
Function 3 can return more bytes than allocated when not running in extended mode, per the last paragraph [here](https://nycplanning.github.io/Geosupport-UPG/chapters/chapterII/section10/). That hasn't caused issue in the past, but with upgrade to python 3.12, we're seeing sporadic segmentation faults in CBBR when calling function 3.

In that linked manual, justification for extended mode not being default behavior is for legacy systems that don't need the additional fields allowed by extended mode. However, whatever benefit this provides seems geared towards more performance/resource-constrained situations than using these python wrappers. I think in the context of this python package, we should default to extended mode when calling function 3 (especially given that 3.12 seems to throw errors because of it)